### PR TITLE
Add gdpr plugin

### DIFF
--- a/rapidpro/Dockerfile
+++ b/rapidpro/Dockerfile
@@ -12,6 +12,9 @@ RUN npm install -g yarn less
 
 WORKDIR /rapidpro
 RUN wget -O - "https://github.com/nyaruka/rapidpro/archive/${RAPIDPRO_TAG}.tar.gz" | tar -xzf - --strip-components=1
+
+RUN git clone https://github.com/IDEMSInternational/rapidpro-gdpr.git /rapidpro/rapidpro_gdpr
+
 RUN poetry install --no-root
 RUN yarn install
 COPY ./middleware.py /rapidpro/idems/

--- a/rapidpro/settings.py
+++ b/rapidpro/settings.py
@@ -80,3 +80,6 @@ BRAND["emails"]["notifications"] = os.getenv("BRAND_EMAILS_NOTIFICATIONS")
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 IDEMS_EXPORT_BASE_URL = f"https://{BRAND['domain']}/idems/export"
 MIDDLEWARE += ("idems.middleware.ExportDownloadMiddleware",)
+
+INSTALLED_APPS += ('rapidpro_gdpr',)
+APP_URLS.append('rapidpro_gdpr.urls') 


### PR DESCRIPTION
Add the GDPR Django plugin.

Pros:
- does not require configuring rapidpro-docker to be able to switch between staging and production tags/forks
Cons:
- does not integrate `runs_actions` endpoint into the UI API explorer, so all verification must be done through external tools.

Tested using `python -m parenttext.rapidpro_api_tools --steps process_deletion_requests` with relavent .env parameters set (namely `DELETION_REQUEST_GROUP="Unsatisfied Customers"`)
1. Add test telegram channel, message it, start contact in Simple Poll flow and complete the flow.
2. Add a contact manually via the UI, edit contact and add it to `Unsatisfied Customers` group
3. Access {DOMAIN}/api/v2/explorer, use get requests to verify that there are: 2 contacts, expected messages, expected runs
4. Run `python -m parenttext.rapidpro_api_tools --steps process_deletion_requests` 
5. Access {DOMAIN}/api/v2/explorer, use get requests to verify that there are: 1 contacts, expected messages (messages from telegram contact have not been deleted, expected runs (runs from telegram contact have not been deleted)
6. Add telegram contact to `Unsatisfied Customers` group
7. Run `python -m parenttext.rapidpro_api_tools --steps process_deletion_requests` 
8. Access {DOMAIN}/api/v2/explorer, use get requests to verify that there are: 0 contacts, no messages (messages from telegram contact have been deleted, no runs (runs from telegram contact have been deleted)